### PR TITLE
Lots of changes to improve compatibility and modularity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ python:
 install:
   - pip install six
   - pip install pycrypto
+  - pip install chardet
 script:
   nosetests --nologcapture

--- a/pdfminer/__init__.py
+++ b/pdfminer/__init__.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 __version__ = '20140915'
 
 if __name__ == '__main__':

--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -20,6 +20,7 @@ from .utils import apply_matrix_pt
 from .utils import mult_matrix
 from .utils import enc
 from .utils import bbox2str
+from . import utils
 
 import six # Python 2+3 compatibility
 
@@ -164,8 +165,11 @@ class TextConverter(PDFConverter):
         return
 
     def write_text(self, text):
-        if self.codec:
-            text = text.encode(self.codec, 'ignore')
+        text = utils.compatible_encode_method(text, self.codec, 'ignore')
+#        if six.PY2 and self.codec:
+#            text = text.encode(self.codec, 'ignore')
+#        if six.PY3 and isinstance(text, bytes):
+#            text = text.decode(self.codec, 'ignore')
         self.outfp.write(text)
         return
 

--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -150,6 +150,23 @@ class PDFConverter(PDFLayoutAnalyzer):
         PDFLayoutAnalyzer.__init__(self, rsrcmgr, pageno=pageno, laparams=laparams)
         self.outfp = outfp
         self.codec = codec
+        if hasattr(self.outfp, 'mode'):
+            if 'b' in self.outfp.mode:
+                self.outfp_binary = True
+            else:
+                self.outfp_binary = False
+        else:
+            import io
+            if isinstance(self.outfp, io.BytesIO):
+                self.outfp_binary = True
+            elif isinstance(self.outfp, io.StringIO):
+                self.outfp_binary = False
+            else:
+                try:
+                    self.outfp.write(u"é")
+                    self.outfp_binary = False
+                except TypeError:
+                    self.outfp_binary = True
         return
 
 
@@ -166,10 +183,8 @@ class TextConverter(PDFConverter):
 
     def write_text(self, text):
         text = utils.compatible_encode_method(text, self.codec, 'ignore')
-#        if six.PY2 and self.codec:
-#            text = text.encode(self.codec, 'ignore')
-#        if six.PY3 and isinstance(text, bytes):
-#            text = text.decode(self.codec, 'ignore')
+        if six.PY3 and self.outfp_binary:
+            text = text.encode()
         self.outfp.write(text)
         return
 

--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 import logging
 import re
 from .pdfdevice import PDFTextDevice

--- a/pdfminer/high_level.py
+++ b/pdfminer/high_level.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 """
 Functions that encapsulate "usual" use-cases for pdfminer, for use making
 bundled scripts and for using pdfminer as a module for routine tasks.

--- a/pdfminer/high_level.py
+++ b/pdfminer/high_level.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Functions that encapsulate "usual" use-cases for pdfminer, for use making
+bundled scripts and for using pdfminer as a module for routine tasks.
+"""
+
+import six
+import sys
+
+from .pdfdocument import PDFDocument
+from .pdfparser import PDFParser
+from .pdfinterp import PDFResourceManager, PDFPageInterpreter
+from .pdfdevice import PDFDevice, TagExtractor
+from .pdfpage import PDFPage
+from .converter import XMLConverter, HTMLConverter, TextConverter
+from .cmapdb import CMapDB
+from .image import ImageWriter
+
+
+def extract_text_to_fp(inf, outfp,
+                    _py2_no_more_posargs=None,  # Bloody Python2 needs a shim
+                    output_type='text', codec='utf-8', laparams = None,
+                    maxpages=0, page_numbers=None, password="", scale=1.0, rotation=0,
+                    layoutmode='normal', output_dir=None, strip_control=False,
+                    debug=False, disable_caching=False, **other):
+    """
+    Parses text from inf-file and writes to outfp file-like object.
+    Takes loads of optional arguments but the defaults are somewhat sane.
+    Beware laparams: Including an empty LAParams is not the same as passing None!
+    Returns nothing, acting as it does on two streams. Use StringIO to get strings.
+    """
+    if six.PY2 and sys.stdin.encoding:
+        password = password.decode(sys.stdin.encoding)
+
+    imagewriter = None
+    if output_dir:
+        imagewriter = ImageWriter(output_dir)
+    
+    rsrcmgr = PDFResourceManager(caching=not disable_caching)
+
+    if output_type == 'text':
+        device = TextConverter(rsrcmgr, outfp, codec=codec, laparams=laparams,
+                               imagewriter=imagewriter)
+
+    if six.PY3 and outfp == sys.stdout:
+        outfp = sys.stdout.buffer
+
+    if output_type == 'xml':
+        device = XMLConverter(rsrcmgr, outfp, codec=codec, laparams=laparams,
+                              imagewriter=imagewriter,
+                              stripcontrol=strip_control)
+    elif output_type == 'html':
+        device = HTMLConverter(rsrcmgr, outfp, codec=codec, scale=scale,
+                               layoutmode=layoutmode, laparams=laparams,
+                               imagewriter=imagewriter)
+    elif output_type == 'tag':
+        device = TagExtractor(rsrcmgr, outfp, codec=codec)
+
+    interpreter = PDFPageInterpreter(rsrcmgr, device)
+    for page in PDFPage.get_pages(inf,
+                                  page_numbers,
+                                  maxpages=maxpages,
+                                  password=password,
+                                  caching=not disable_caching,
+                                  check_extractable=True):
+        page.rotate = (page.rotate + rotation) % 360
+        interpreter.process_page(page)    
+

--- a/pdfminer/high_level.py
+++ b/pdfminer/high_level.py
@@ -28,6 +28,21 @@ def extract_text_to_fp(inf, outfp,
     Takes loads of optional arguments but the defaults are somewhat sane.
     Beware laparams: Including an empty LAParams is not the same as passing None!
     Returns nothing, acting as it does on two streams. Use StringIO to get strings.
+    
+    output_type: May be 'text', 'xml', 'html', 'tag'. Only 'text' works properly.
+    codec: Text decoding codec
+    laparams: An LAParams object from pdfminer.layout.
+        Default is None but may not layout correctly.
+    maxpages: How many pages to stop parsing after
+    page_numbers: zero-indexed page numbers to operate on.
+    password: For encrypted PDFs, the password to decrypt.
+    scale: Scale factor
+    rotation: Rotation factor
+    layoutmode: Default is 'normal', see pdfminer.converter.HTMLConverter
+    output_dir: If given, creates an ImageWriter for extracted images.
+    strip_control: Does what it says on the tin
+    debug: Output more logging data
+    disable_caching: Does what it says on the tin
     """
     if six.PY2 and sys.stdin.encoding:
         password = password.decode(sys.stdin.encoding)

--- a/pdfminer/pdfdevice.py
+++ b/pdfminer/pdfdevice.py
@@ -1,11 +1,7 @@
 #!/usr/bin/env python
-from .utils import mult_matrix
-from .utils import translate_matrix
-from .utils import enc
-from .utils import bbox2str
-from .utils import isnumber
 from .pdffont import PDFUnicodeNotDefined
 
+from . import utils
 
 ##  PDFDevice
 ##
@@ -62,7 +58,7 @@ class PDFDevice(object):
 class PDFTextDevice(PDFDevice):
 
     def render_string(self, textstate, seq):
-        matrix = mult_matrix(textstate.matrix, self.ctm)
+        matrix = utils.mult_matrix(textstate.matrix, self.ctm)
         font = textstate.font
         fontsize = textstate.fontsize
         scaling = textstate.scaling * .01
@@ -87,14 +83,14 @@ class PDFTextDevice(PDFDevice):
         (x, y) = pos
         needcharspace = False
         for obj in seq:
-            if isnumber(obj):
+            if utils.isnumber(obj):
                 x -= obj*dxscale
                 needcharspace = True
             else:
                 for cid in font.decode(obj):
                     if needcharspace:
                         x += charspace
-                    x += self.render_char(translate_matrix(matrix, (x, y)),
+                    x += self.render_char(utils.translate_matrix(matrix, (x, y)),
                                           font, fontsize, scaling, rise, cid)
                     if cid == 32 and wordspace:
                         x += wordspace
@@ -106,14 +102,14 @@ class PDFTextDevice(PDFDevice):
         (x, y) = pos
         needcharspace = False
         for obj in seq:
-            if isnumber(obj):
+            if utils.isnumber(obj):
                 y -= obj*dxscale
                 needcharspace = True
             else:
                 for cid in font.decode(obj):
                     if needcharspace:
                         y += charspace
-                    y += self.render_char(translate_matrix(matrix, (x, y)),
+                    y += self.render_char(utils.translate_matrix(matrix, (x, y)),
                                           font, fontsize, scaling, rise, cid)
                     if cid == 32 and wordspace:
                         y += wordspace
@@ -140,6 +136,7 @@ class TagExtractor(PDFDevice):
         font = textstate.font
         text = ''
         for obj in seq:
+            obj = utils.make_compat_str(obj)
             if not isinstance(obj, str):
                 continue
             chars = font.decode(obj)
@@ -148,33 +145,36 @@ class TagExtractor(PDFDevice):
                     char = font.to_unichr(cid)
                     text += char
                 except PDFUnicodeNotDefined:
+                    print(chars)
                     pass
-        self.outfp.write(enc(text, self.codec))
+        self.outfp.write(utils.enc(text, self.codec))
         return
 
     def begin_page(self, page, ctm):
-        self.outfp.write('<page id="%s" bbox="%s" rotate="%d">' %
-                         (self.pageno, bbox2str(page.mediabox), page.rotate))
+        output = '<page id="%s" bbox="%s" rotate="%d">' % (self.pageno, utils.bbox2str(page.mediabox), page.rotate)
+        self.outfp.write(utils.make_compat_bytes(output))
         return
 
     def end_page(self, page):
-        self.outfp.write('</page>\n')
+        self.outfp.write(utils.make_compat_bytes('</page>\n'))
         self.pageno += 1
         return
 
     def begin_tag(self, tag, props=None):
         s = ''
         if isinstance(props, dict):
-            s = ''.join(' %s="%s"' % (enc(k), enc(str(v))) for (k, v)
+            s = ''.join(' %s="%s"' % (utils.enc(k), utils.enc(str(v))) for (k, v)
                         in sorted(props.iteritems()))
-        self.outfp.write('<%s%s>' % (enc(tag.name), s))
+        out_s = '<%s%s>' % (utils.enc(tag.name), s)
+        self.outfp.write(utils.make_compat_bytes(out_s))
         self._stack.append(tag)
         return
 
     def end_tag(self):
         assert self._stack
         tag = self._stack.pop(-1)
-        self.outfp.write('</%s>' % enc(tag.name))
+        out_s = '</%s>' % utils.enc(tag.name)
+        self.outfp.write(utils.make_compat_bytes(out_s))
         return
 
     def do_tag(self, tag, props=None):

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -10,6 +10,9 @@ INF = (1<<31) - 1
 import six  #Python 2+3 compatibility
 import chardet  # For str encoding detection in Py3
 
+if six.PY3:
+    unicode = str
+
 def make_compat_bytes(in_str):
     "In Py2, does nothing. In Py3, converts to bytes, encoding to unicode."
     assert isinstance(in_str, str)
@@ -20,7 +23,7 @@ def make_compat_bytes(in_str):
 
 def make_compat_str(in_str):
     "In Py2, does nothing. In Py3, converts to string, guessing encoding."
-    assert isinstance(in_str, (bytes, str))
+    assert isinstance(in_str, (bytes, str, unicode))
     if six.PY3 and isinstance(in_str, bytes):
         enc = chardet.detect(in_str)
         in_str = in_str.decode(enc['encoding'])
@@ -29,7 +32,7 @@ def make_compat_str(in_str):
 def compatible_encode_method(bytesorstring, encoding='utf-8', erraction='ignore'):
     "When Py2 str.encode is called, it often means bytes.encode in Py3. This does either."
     if six.PY2:
-        assert isinstance(bytesorstring, str), ("Error: Assumed was calling"
+        assert isinstance(bytesorstring, (str, unicode)), ("Error: Assumed was calling"
             " encode() on a string in Py2: {}").format(type(bytesorstring))
         return bytesorstring.encode(encoding, erraction)
     if six.PY3:

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -3,9 +3,40 @@
 Miscellaneous Routines.
 """
 import struct
-INF=2147483647 #from sys import maxint as INF #doesn't work anymore under Python3, but PDF still uses 32 bits ints
+# from sys import maxint as INF #doesn't work anymore under Python3,
+# but PDF still uses 32 bits ints
+INF = (1<<31) - 1
 
-import six #Python 2+3 compatibility
+import six  #Python 2+3 compatibility
+import chardet  # For str encoding detection in Py3
+
+def make_compat_bytes(in_str):
+    "In Py2, does nothing. In Py3, converts to bytes, encoding to unicode."
+    assert isinstance(in_str, str)
+    if six.PY2:
+        return in_str
+    else:
+        return in_str.encode()
+
+def make_compat_str(in_str):
+    "In Py2, does nothing. In Py3, converts to string, guessing encoding."
+    assert isinstance(in_str, (bytes, str))
+    if six.PY3 and isinstance(in_str, bytes):
+        enc = chardet.detect(in_str)
+        in_str = in_str.decode(enc['encoding'])
+    return in_str
+
+def compatible_encode_method(bytesorstring, encoding='utf-8', erraction='ignore'):
+    "When Py2 str.encode is called, it often means bytes.encode in Py3. This does either."
+    if six.PY2:
+        assert isinstance(bytesorstring, str), ("Error: Assumed was calling"
+            " encode() on a string in Py2: {}").format(type(bytesorstring))
+        return bytesorstring.encode(encoding, erraction)
+    if six.PY3:
+        if isinstance(bytesorstring, str): return bytesorstring
+        assert isinstance(bytesorstring, bytes), ("Error: Assumed was calling"
+            " encode() on a bytes in Py3: {}").format(type(bytesorstring))
+        return bytesorstring.decode(encoding, erraction)
 
 ##  PNG Predictor
 ##

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -8,9 +8,9 @@ import struct
 INF = (1<<31) - 1
 
 import six  #Python 2+3 compatibility
-import chardet  # For str encoding detection in Py3
 
 if six.PY3:
+    import chardet  # For str encoding detection in Py3
     unicode = str
 
 def make_compat_bytes(in_str):

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,14 @@
 #from distutils.core import setup
 from setuptools import setup
 from pdfminer import __version__
+import sys
 
 setup(
     name='pdfminer.six',
     version=__version__,
     packages=['pdfminer',],
     package_data={'pdfminer': ['cmap/*.pickle.gz']},
-    requires=['six', 'chardet'],
+    requires=['six', 'chardet'] if sys.version_info.major>2 else ['six'],
     description='PDF parser and analyzer',
     long_description='''fork of PDFMiner using six for Python 2+3 compatibility
     

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-from distutils.core import setup
+#from distutils.core import setup
+from setuptools import setup
 from pdfminer import __version__
 
 setup(
@@ -7,7 +8,7 @@ setup(
     version=__version__,
     packages=['pdfminer',],
     package_data={'pdfminer': ['cmap/*.pickle.gz']},
-    requires=['six'],
+    requires=['six', 'chardet'],
     description='PDF parser and analyzer',
     long_description='''fork of PDFMiner using six for Python 2+3 compatibility
     

--- a/tests/test_tools_dumppdf.py
+++ b/tests/test_tools_dumppdf.py
@@ -1,9 +1,16 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+import six
 
 import nose, logging, os
 
-import tools.dumppdf as dumppdf
+if six.PY3:
+    from tools import dumppdf
+elif six.PY2:
+    import os, sys
+#    raise Exception("{}\n{}".format(sys.path, os.path.abspath(os.path.curdir)))
+    sys.path.append(os.path.abspath(os.path.curdir))
+    import tools.dumppdf as dumppdf
 
 path=os.path.dirname(os.path.abspath(__file__))+'/'
 

--- a/tests/test_tools_dumppdf.py
+++ b/tests/test_tools_dumppdf.py
@@ -8,7 +8,6 @@ if six.PY3:
     from tools import dumppdf
 elif six.PY2:
     import os, sys
-#    raise Exception("{}\n{}".format(sys.path, os.path.abspath(os.path.curdir)))
     sys.path.append(os.path.abspath(os.path.curdir))
     import tools.dumppdf as dumppdf
 

--- a/tests/test_tools_pdf2txt.py
+++ b/tests/test_tools_pdf2txt.py
@@ -14,7 +14,7 @@ def run(datapath,filename,options=None):
         s='pdf2txt -o%s %s %s'%(o,options,i)
     else:
          s='pdf2txt -o%s %s'%(o,i)
-    pdf2txt.main(s.split(' '))
+    pdf2txt.main(s.split(' ')[1:])
 
 class TestDumpPDF():
     

--- a/tools/pdf2txt.py
+++ b/tools/pdf2txt.py
@@ -131,8 +131,8 @@ def extract_text(files=[], outfile='-',
     if output_dir:
         imagewriter = ImageWriter(output_dir)
 
-    if six.PY2 and sys.stdin.encoding:
-        password = password.decode(sys.stdin.encoding)
+#    if six.PY2 and sys.stdin.encoding:
+#        password = password.decode(sys.stdin.encoding)
     
     if output_type == "text" and outfile != "-":
         for override, alttype in (  (".htm", "html"),
@@ -149,38 +149,39 @@ def extract_text(files=[], outfile='-',
     else:
         outfp = open(outfile, "wb")
     
-    rsrcmgr = PDFResourceManager(caching=not disable_caching)
+#    rsrcmgr = PDFResourceManager(caching=not disable_caching)
 
-    if output_type == 'text':
-        device = TextConverter(rsrcmgr, outfp, codec=codec, laparams=laparams,
-                               imagewriter=imagewriter)
+#    if output_type == 'text':
+#        device = TextConverter(rsrcmgr, outfp, codec=codec, laparams=laparams,
+#                               imagewriter=imagewriter)
 
-    if six.PY3 and outfp == sys.stdout:
-        outfp = sys.stdout.buffer
+#    if six.PY3 and outfp == sys.stdout:
+#        outfp = sys.stdout.buffer
 
-    if output_type == 'xml':
-        device = XMLConverter(rsrcmgr, outfp, codec=codec, laparams=laparams,
-                              imagewriter=imagewriter,
-                              stripcontrol=strip_control)
-    elif output_type == 'html':
-        device = HTMLConverter(rsrcmgr, outfp, codec=codec, scale=scale,
-                               layoutmode=layoutmode, laparams=laparams,
-                               imagewriter=imagewriter)
-    elif output_type == 'tag':
-        device = TagExtractor(rsrcmgr, outfp, codec=codec)
+#    if output_type == 'xml':
+#        device = XMLConverter(rsrcmgr, outfp, codec=codec, laparams=laparams,
+#                              imagewriter=imagewriter,
+#                              stripcontrol=strip_control)
+#    elif output_type == 'html':
+#        device = HTMLConverter(rsrcmgr, outfp, codec=codec, scale=scale,
+#                               layoutmode=layoutmode, laparams=laparams,
+#                               imagewriter=imagewriter)
+#    elif output_type == 'tag':
+#        device = TagExtractor(rsrcmgr, outfp, codec=codec)
 
     for fname in files:
         with open(fname, "rb") as fp:
-            interpreter = PDFPageInterpreter(rsrcmgr, device)
-            for page in PDFPage.get_pages(fp,
-                                          page_numbers,
-                                          maxpages=maxpages,
-                                          password=password,
-                                          caching=not disable_caching,
-                                          check_extractable=True):
-                page.rotate = (page.rotate + rotation) % 360
-                interpreter.process_page(page)
-    device.close()
+            extract_text_to_fp(fp, **locals())
+#            interpreter = PDFPageInterpreter(rsrcmgr, device)
+#            for page in PDFPage.get_pages(fp,
+#                                          page_numbers,
+#                                          maxpages=maxpages,
+#                                          password=password,
+#                                          caching=not disable_caching,
+#                                          check_extractable=True):
+#                page.rotate = (page.rotate + rotation) % 360
+#                interpreter.process_page(page)
+#    device.close()
     return outfp
 
 # main

--- a/tools/pdf2txt.py
+++ b/tools/pdf2txt.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
+"""
+Converts PDF text content (though not images containing text) to plain text, html, xml or "tags".
+"""
 import sys
+import logging
+import six
+
 from pdfminer.pdfdocument import PDFDocument
 from pdfminer.pdfparser import PDFParser
 from pdfminer.pdfinterp import PDFResourceManager, PDFPageInterpreter
@@ -9,11 +15,110 @@ from pdfminer.converter import XMLConverter, HTMLConverter, TextConverter
 from pdfminer.cmapdb import CMapDB
 from pdfminer.layout import LAParams
 from pdfminer.image import ImageWriter
-import logging
-import six
 
 # main
 def main(argv):
+    import argparse
+    P = argparse.ArgumentParser(description=__doc__)
+    P.add_argument("files", type=str, nargs="+", help="Files to process.")
+    P.add_argument("-d", "--debug", default=False, action="store_true", help="Debug output.")
+    P.add_argument("-p", "--pagenos", type=str, help="Comma-separated list of page numbers to parse. Included for legacy applications, use -P/--page-numbers for more idiomatic argument entry.")
+    P.add_argument("--page-numbers", type=int, nargs="+", help="Alternative to --pagenos with space-separated numbers; supercedes --pagenos where it is used.")
+    P.add_argument("-m", "--maxpages", type=int, default=0, help = "Maximum pages to parse")
+    P.add_argument("-P", "--password", type=str, default="", help = "Decryption password for PDF")
+#    P.add_argument("-o", "--outfile", type=argparse.FileType("w"), default=sys.stdout, help="Output file (default stdout)")
+    P.add_argument("-o", "--outfile", type=str, default="-", help="Output file (default/'-' is stdout)")
+    P.add_argument("-t", "--output_type", type=str, default="text", help = "Output type: text|html|xml|tag (default is text)")
+    P.add_argument("-c", "--codec", type=str, default="utf-8", help = "Text encoding")
+    P.add_argument("-s", "--scale", type=float, default=1.0, help = "Scale")
+    P.add_argument("-A", "--all-texts", default=None, action="store_true", help="LAParams all texts")
+    P.add_argument("-V", "--detect-vertical", default=None, action="store_true", help="LAParams detect vertical")
+    P.add_argument("-W", "--word-margin", type=float, default=None, help = "LAParams word margin")
+    P.add_argument("-M", "--char-margin", type=float, default=None, help = "LAParams char margin")
+    P.add_argument("-L", "--line-margin", type=float, default=None, help = "LAParams line margin")
+    P.add_argument("-F", "--boxes-flow", type=float, default=None, help = "LAParams boxes flow")
+    P.add_argument("-Y", "--layoutmode", default="normal", type=str, help="HTML Layout Mode")
+    P.add_argument("-n", "--no-laparams", default=False, action="store_true", help = "Pass None as LAParams")
+    P.add_argument("-R", "--rotation", default=0, type=int, help = "Rotation")
+    P.add_argument("-O", "--output-dir", default=None, help="Output directory for images")
+    P.add_argument("-C", "--disable-caching", default=False, action="store_true", help="Disable caching")
+    P.add_argument("-S", "--strip-control", default=False, action="store_true", help="Strip control in XML mode")
+    A = P.parse_args()
+
+    if A.no_laparams:
+        laparams = None
+    else:
+        laparams = LAParams()
+        for param in ("all_texts", "detect_vertical", "word_margin", "char_margin", "line_margin", "boxes_flow"):
+            param_arg = getattr(A, param, None)
+            if param_arg is not None:
+                setattr(laparams, param, param_arg)
+
+    if A.page_numbers:
+        A.page_numbers = set([x-1 for x in A.page_numbers])
+    if A.pagenos:
+        A.page_numbers = set([int(x)-1 for x in A.pagenos.split(",")])
+    
+    imagewriter = None
+    if A.output_dir:
+        imagewriter = ImageWriter(A.output_dir)
+
+    if six.PY2 and sys.stdin.encoding:
+        A.password = A.password.decode(sys.stdin.encoding)
+
+    if A.output_type == "text" and A.outfile != "-":
+        for override, alttype in (  (".htm", "html"),
+                                    (".html", "html"),
+                                    (".xml", "xml"),
+                                    (".tag", "tag") ):
+            if A.outfile.endswith(override):
+                A.output_type = alttype
+
+    if A.outfile == "-":
+        outfp = sys.stdout
+        if outfp.encoding is not None:
+            A.codec = 'utf-8'
+            #A.codec = outfp.encoding
+    else:
+        outfp = open(A.outfile, "wb")
+
+    rsrcmgr = PDFResourceManager(caching=not A.disable_caching)
+
+    if A.output_type == 'text':
+        device = TextConverter(rsrcmgr, outfp, codec=A.codec, laparams=laparams,
+                               imagewriter=imagewriter)
+    elif A.output_type == 'xml':
+        if six.PY3 and outfp == sys.stdout:
+            outfp = sys.stdout.buffer
+        device = XMLConverter(rsrcmgr, outfp, codec=A.codec, laparams=laparams,
+                              imagewriter=imagewriter,
+                              stripcontrol=A.strip_control)
+    elif A.output_type == 'html':
+        if six.PY3 and outfp == sys.stdout:
+            outfp = sys.stdout.buffer
+        device = HTMLConverter(rsrcmgr, outfp, codec=A.codec, scale=A.scale,
+                               layoutmode=A.layoutmode, laparams=laparams,
+                               imagewriter=imagewriter)
+    elif A.output_type == 'tag':
+        if six.PY3 and outfp == sys.stdout:
+            outfp = sys.stdout.buffer
+        device = TagExtractor(rsrcmgr, outfp, codec=A.codec)
+    else:
+        return usage()
+    for fname in A.files:
+        fp = open(fname, 'rb')
+        interpreter = PDFPageInterpreter(rsrcmgr, device)
+        for page in PDFPage.get_pages(fp, A.page_numbers,
+                                      maxpages=A.maxpages, password=A.password,
+                                      caching=not A.disable_caching, check_extractable=True):
+            page.rotate = (page.rotate + A.rotation) % 360
+            interpreter.process_page(page)
+        fp.close()
+    device.close()
+    outfp.close()
+    return
+
+def main_old(argv):
     import getopt
     def usage():
         print ('usage: %s [-d] [-p pagenos] [-m maxpages] [-P password] [-o output]'
@@ -98,6 +203,8 @@ def main(argv):
                                layoutmode=layoutmode, laparams=laparams,
                                imagewriter=imagewriter)
     elif outtype == 'tag':
+        if six.PY3 and outfp == sys.stdout:
+            outfp = sys.stdout.buffer
         device = TagExtractor(rsrcmgr, outfp, codec=codec)
     else:
         return usage()
@@ -114,4 +221,5 @@ def main(argv):
     outfp.close()
     return
 
+#if __name__ == '__main__': sys.exit(main_old(sys.argv))
 if __name__ == '__main__': sys.exit(main(sys.argv))

--- a/tools/pdf2txt.py
+++ b/tools/pdf2txt.py
@@ -9,21 +9,6 @@ import pdfminer.high_level
 import pdfminer.layout
 
 
-def _check_arg():
-    """
-    Type-checking the ugly way, because we can't do arg annotations and reflection
-    in Python 2.
-    """
-    arg = locals()[arg_name]
-    assert isinstance(arg, arg_permitted), ("Argument '{}' should be of type(s)"
-            " '{}' but is type '{}'").format(arg_name, arg_permitted, type(arg))
-    if contains_permitted is not None and arg:
-        for contained in arg:
-            assert isinstance(contained, contains_permitted), ("Value within"
-                    " argument '{}' should be of type '{}' but is '{}'"
-                    ).format(arg_name, contains_permitted, type(contained))
-
-
 def extract_text(files=[], outfile='-',
             _py2_no_more_posargs=None,  # Bloody Python2 needs a shim
             no_laparams=False, all_texts=None, detect_vertical=None, # LAParams


### PR DESCRIPTION
Hi, I started hacking on pdfminer.six to help make it more useful as a module for ease-of-use. So, I've made a bunch of changes here, but all tests appear to pass. At a high-level here:

* Added a dependency, chardet, but only for Py3: The setup.py script determines whether to install or not by major version number. This is used to auto-detect character encoding when casting from `bytes` to `str` when an encoding is not known/explicit.
* Rewrote, then broke out in to sub-functions, the main logic behind `tools/pdf2txt.py`, because this is probably 90% of people's use-cases for PDFMiner and it really belongs as a high-level function in the module. Switched to `argparse` for Arguments, but tried to keep the interface compatible with the previous script to try not to break downstream users. This project doesn't have tests to verify that this terminal usage has remained un-broken, unfortunately.
* Added, to that effect, a `high_level.py` file to the module and put the logic from `pdf2txt.py` into a function: `extract_text_to_fp(input: file_like, output: file_like, <many positional arguments>)->None`. pdf2txt now prepares a call to this function for each input file from command line args and uses it for the core operation. It's less efficient than preparing all up front and re-using parts *for a run of many files*, but I think that use-case deserves a separate high-level function or an in-module re-jigger.

Sorry there are so many changes bundled together. I've run the tests in Python2.7 and Python3.4 (and had to hack them a bit to make them run in both versions, there's an error in there to report upstream to pytest where Py2 doesn't correctly setup paths and Py3 does, so I shimmed it) and had all-clears, though the tests only verify that the script runs without exception, not the actual content of the output; that needs work, too. I manually verified that Py2/Py3 usage generates identical output on several PDFs, and that the output is substantially similar (in fact, better laid out in places) to pdftotext.

Looking forward to your thoughts: I made these changes to facilitate a project I'm working on so I'd love to see them in Pip someday if they get the all-clear! :)