### PR TITLE
Ensure to install required libraries on installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     version=__version__,
     packages=['pdfminer',],
     package_data={'pdfminer': ['cmap/*.pickle.gz']},
-    requires=['six', 'chardet'] if sys.version_info.major>2 else ['six'],
+    install_requires=['six', 'chardet'] if sys.version_info.major>2 else ['six'],
     description='PDF parser and analyzer',
     long_description='''fork of PDFMiner using six for Python 2+3 compatibility
     


### PR DESCRIPTION
### Problem

Required libraries, six and chardet, are not successfully installed on installation.

The keyword argument `requires` in `setup()` seems to be a typo. It should be `install_requires`.

setup.py:

```py
...
setup(
    name='pdfminer.six',
    version=__version__,
    packages=['pdfminer',],
    package_data={'pdfminer': ['cmap/*.pickle.gz']},
    requires=['six', 'chardet'] if sys.version_info.major>2 else ['six'],
...
```

### Before (goulu/pdfminer's master branch)

Dependencies are not installed. This causes `ImportError: No module named 'six'`

```sh
orangepro:pdf_test orange$ pyvenv venv-before
orangepro:pdf_test orange$ . venv-before/bin/activate
(venv-before) orangepro:pdf_test orange$ PIP_DOWNLOAD_CACHE= pip install https://github.com/goulu/pdfminer/archive/master.tar.gz
Downloading/unpacking https://github.com/goulu/pdfminer/archive/master.tar.gz
  Downloading master.tar.gz (unknown size): 4.2MB downloaded
  Running setup.py (path:/var/folders/5r/68b9_znx5v56__ll38xqm2ym0000gn/T/pip-cwhvzssg-build/setup.py) egg_info for package from https://github.com/goulu/pdfminer/archive/master.tar.gz

    warning: no files found matching '*.txt'
Installing collected packages: pdfminer.six
  Running setup.py install for pdfminer.six
    changing mode of build/scripts-3.4/pdf2txt.py from 644 to 755
    changing mode of build/scripts-3.4/dumppdf.py from 644 to 755
    changing mode of build/scripts-3.4/latin2ascii.py from 644 to 755

    warning: no files found matching '*.txt'
    changing mode of /Users/orange/samplecodes/pdf_test/venv-before/bin/dumppdf.py to 755
    changing mode of /Users/orange/samplecodes/pdf_test/venv-before/bin/latin2ascii.py to 755
    changing mode of /Users/orange/samplecodes/pdf_test/venv-before/bin/pdf2txt.py to 755
Successfully installed pdfminer.six
Cleaning up...
(venv-before) orangepro:pdf_test orange$ pip freeze
pdfminer.six==20150601
(venv-before) orangepro:pdf_test orange$ pdf2txt.py -h
Traceback (most recent call last):
  File "/Users/orange/samplecodes/pdf_test/venv-before/bin/pdf2txt.py", line 7, in <module>
    import six
ImportError: No module named 'six'
```


### After (orangain/pdfminer's install_requires branch)

Dependencies are successfully installed. pdfminer works fine.

```sh
orangepro:pdf_test orange$ pyvenv venv-after
orangepro:pdf_test orange$ . venv-after/bin/activate
(venv-after) orangepro:pdf_test orange$ PIP_DOWNLOAD_CACHE= pip install https://github.com/orangain/pdfminer/archive/install_requires.tar.gz
Downloading/unpacking https://github.com/orangain/pdfminer/archive/install_requires.tar.gz
  Downloading install_requires.tar.gz (unknown size): 4.2MB downloaded
  Running setup.py (path:/var/folders/5r/68b9_znx5v56__ll38xqm2ym0000gn/T/pip-1zvplcap-build/setup.py) egg_info for package from https://github.com/orangain/pdfminer/archive/install_requires.tar.gz

    warning: no files found matching '*.txt'
Downloading/unpacking six (from pdfminer.six==20150601)
  Downloading six-1.9.0-py2.py3-none-any.whl
Downloading/unpacking chardet (from pdfminer.six==20150601)
  Downloading chardet-2.3.0.tar.gz (164kB): 164kB downloaded
  Running setup.py (path:/Users/orange/samplecodes/pdf_test/venv-after/build/chardet/setup.py) egg_info for package chardet

    warning: no files found matching 'COPYING'
    warning: no files found matching '*.html' under directory 'docs'
    warning: no files found matching '*.css' under directory 'docs'
    warning: no files found matching '*.png' under directory 'docs'
    warning: no files found matching '*.gif' under directory 'docs'
Installing collected packages: six, chardet, pdfminer.six
  Running setup.py install for chardet

    warning: no files found matching 'COPYING'
    warning: no files found matching '*.html' under directory 'docs'
    warning: no files found matching '*.css' under directory 'docs'
    warning: no files found matching '*.png' under directory 'docs'
    warning: no files found matching '*.gif' under directory 'docs'
    Installing chardetect script to /Users/orange/samplecodes/pdf_test/venv-after/bin
  Running setup.py install for pdfminer.six
    changing mode of build/scripts-3.4/pdf2txt.py from 644 to 755
    changing mode of build/scripts-3.4/dumppdf.py from 644 to 755
    changing mode of build/scripts-3.4/latin2ascii.py from 644 to 755

    warning: no files found matching '*.txt'
    changing mode of /Users/orange/samplecodes/pdf_test/venv-after/bin/dumppdf.py to 755
    changing mode of /Users/orange/samplecodes/pdf_test/venv-after/bin/latin2ascii.py to 755
    changing mode of /Users/orange/samplecodes/pdf_test/venv-after/bin/pdf2txt.py to 755
Successfully installed six chardet pdfminer.six
Cleaning up...
(venv-after) orangepro:pdf_test orange$ pip freeze
chardet==2.3.0
pdfminer.six==20150601
six==1.9.0
(venv-after) orangepro:pdf_test orange$ pdf2txt.py -h
usage: pdf2txt.py [-h] [-d] [-p PAGENOS]
                  [--page-numbers PAGE_NUMBERS [PAGE_NUMBERS ...]]
                  [-m MAXPAGES] [-P PASSWORD] [-o OUTFILE] [-t OUTPUT_TYPE]
                  [-c CODEC] [-s SCALE] [-A] [-V] [-W WORD_MARGIN]
                  [-M CHAR_MARGIN] [-L LINE_MARGIN] [-F BOXES_FLOW]
                  [-Y LAYOUTMODE] [-n] [-R ROTATION] [-O OUTPUT_DIR] [-C] [-S]
                  files [files ...]
...
```