### PR TITLE
Ensure that command line tools use LF line endings to work on Linux/OS X

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.py text eol=lf


### PR DESCRIPTION
## Problem

Command line tools, `pdf2txt.py` and `dumppdf.py`, does not work when installed via pip on Linux/OS X.

```
$ pip install pdfminer.six
Downloading/unpacking pdfminer.six
...
Successfully installed pdfminer.six six chardet
Cleaning up...
$ pdf2txt.py
env: python\r: No such file or directory
$ dumppdf.py
env: python\r: No such file or directory
```

This is because `tools/pdf2txt.py` and `tools/dumppdf.py`  uploaded on the PyPI contain CRLF line endings. The line endings should be LF to work on Linux/OS X.

Note that installing by `python setup.py install` does not cause this issue because setuptools generates a wrapper script for `pdf2txt.py` and `dumppdf.py` which have LF line endings. However I believe PDFMiner.six should be installable via pip because pip is a de facto standard package manager in Python community today.

## Changes

This PR add `.gitattributes` to ensure that `*.py` files are always checked out with LF line endings regardless of individual's git settings even on Windows. I believe the PR will fix the problem and prevent future regression. After adding `.gitattributes`, you may need to reset all files to get LF line endings by:

```
$ git rm --cached -r .
$ git reset --hard
```

See also:

Dealing with line endings - User Documentation
https://help.github.com/articles/dealing-with-line-endings/