### PR TITLE
Fix import of Django settings

### DIFF
--- a/pdfminer/settings.py
+++ b/pdfminer/settings.py
@@ -1,8 +1,8 @@
 STRICT = True
 
 try:
-    from django.conf import django_settings
-    STRICT = getattr(django_settings, 'PDF_MINER_IS_STRICT', STRICT)
+    from django.conf import settings
+    STRICT = getattr(settings, 'PDF_MINER_IS_STRICT', STRICT)
 except Exception:
     # in case it's not a django project
     pass


### PR DESCRIPTION
Settings in Django are imported as such, see https://docs.djangoproject.com/en/1.10/topics/settings/#using-settings-in-python-code

I'm running issues trying to bypass the `STRICT` parameter and this proposal should allow end developers to override this setting in their projects.