### PR TITLE
bugfix: if fontname argument type is bytes then skip

### DIFF
--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -275,6 +275,8 @@ def decode_text(s):
 # enc
 def enc(x, codec='ascii'):
     """Encodes a string for SGML/XML/HTML"""
+    if isinstance(x, bytes):
+        return ''
     x = x.replace('&', '&amp;').replace('>', '&gt;').replace('<', '&lt;').replace('"', '&quot;')
     if codec:
         x = x.encode(codec, 'xmlcharrefreplace')


### PR DESCRIPTION
Hello
I found the following issue.
https://github.com/goulu/pdfminer/issues/42

The reason for the issue is that sometimes the fontname is not recognized as the string. 
As a solution, I added to check the type of x, and if x is a byte, it would skip working.
